### PR TITLE
Set DefaultView class frame location to center of display

### DIFF
--- a/src/org/graphstream/ui/swingViewer/DefaultView.java
+++ b/src/org/graphstream/ui/swingViewer/DefaultView.java
@@ -216,6 +216,7 @@ public class DefaultView extends View implements WindowListener
 				frame.setLayout(new BorderLayout());
 				frame.add(this, BorderLayout.CENTER);
 				frame.setSize(800, 600);
+				frame.setLocationRelativeTo(null);
 				frame.setVisible(true);
 				frame.addWindowListener(this);
 				frame.addKeyListener(shortcuts);


### PR DESCRIPTION
Have the graph viewer (window - JFrame) centred by default when it's displayed.
