### PR TITLE
Bugfix: getResource(url) return null

### DIFF
--- a/src/org/graphstream/ui/graphicGraph/stylesheet/StyleSheet.java
+++ b/src/org/graphstream/ui/graphicGraph/stylesheet/StyleSheet.java
@@ -421,7 +421,8 @@ public class StyleSheet {
 	public void parseFromURL(String url) throws IOException {
 		URL u = StyleSheet.class.getClassLoader().getResource(url);
 		if (u == null) {
-			File f = new File(url);
+			String fileUrl = url.replace("file://", "");
+			File f = new File(fileUrl);
 
 			if (f.exists())
 				u = f.toURI().toURL();


### PR DESCRIPTION
A new File object was created with the url string without the "file://" prefix being removed.
 That would always result in a file that does not exist, so now the prefix is removed.