### PR TITLE
Make junit a test-scoped dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,7 @@
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<optional>false</optional>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.graphstream</groupId>


### PR DESCRIPTION
JUnit is apparently needed for tests only, so if I am not mistaken, it would
make sense to make it a test-only dependency.
