### PR TITLE
Remove all link to AWT/SWING in the generic ui part of gs-core.

### DIFF
--- a/src-test/org/graphstream/ui/viewer/test/DemoAllInSwing.java
+++ b/src-test/org/graphstream/ui/viewer/test/DemoAllInSwing.java
@@ -33,6 +33,7 @@ package org.graphstream.ui.viewer.test;
 
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.implementations.MultiGraph;
+import org.graphstream.ui.swingViewer.ViewPanel;
 import org.graphstream.ui.view.Viewer;
 
 import javax.swing.JFrame;
@@ -90,7 +91,7 @@ class InitializeApplication extends JFrame implements Runnable {
    
   		// On ins�re la vue principale du viewer dans la JFrame.
   		
-		add(viewer.addDefaultView( false ), BorderLayout.CENTER );
+		add((ViewPanel) viewer.addDefaultView( false ), BorderLayout.CENTER );
 		setDefaultCloseOperation(EXIT_ON_CLOSE);
 		setSize(800, 600);
 		setVisible(true);

--- a/src/org/graphstream/graph/implementations/AbstractGraph.java
+++ b/src/org/graphstream/graph/implementations/AbstractGraph.java
@@ -51,7 +51,7 @@ import org.graphstream.stream.file.FileSource;
 import org.graphstream.stream.file.FileSourceFactory;
 import org.graphstream.ui.layout.Layout;
 import org.graphstream.ui.layout.Layouts;
-import org.graphstream.ui.swingViewer.GraphRenderer;
+import org.graphstream.ui.view.GraphRenderer;
 import org.graphstream.ui.view.Viewer;
 import org.graphstream.util.GraphListeners;
 

--- a/src/org/graphstream/stream/file/FileSinkImages.java
+++ b/src/org/graphstream/stream/file/FileSinkImages.java
@@ -58,7 +58,7 @@ import org.graphstream.ui.graphicGraph.GraphicGraph;
 import org.graphstream.ui.layout.Layout;
 import org.graphstream.ui.layout.LayoutRunner;
 import org.graphstream.ui.layout.Layouts;
-import org.graphstream.ui.swingViewer.GraphRenderer;
+import org.graphstream.ui.view.GraphRenderer;
 
 /**
  * Output graph in image files.

--- a/src/org/graphstream/ui/swingViewer/DefaultView.java
+++ b/src/org/graphstream/ui/swingViewer/DefaultView.java
@@ -35,6 +35,8 @@ import org.graphstream.ui.graphicGraph.GraphicElement;
 import org.graphstream.ui.graphicGraph.GraphicGraph;
 import org.graphstream.ui.view.Viewer;
 import org.graphstream.ui.view.Camera;
+import org.graphstream.ui.view.GraphRenderer;
+import org.graphstream.ui.view.LayerRenderer;
 import org.graphstream.ui.view.util.DefaultMouseManager;
 import org.graphstream.ui.view.util.DefaultShortcutManager;
 import org.graphstream.ui.view.util.MouseManager;
@@ -102,9 +104,8 @@ import java.util.Collection;
  * graph attribute is the identifier of the view.
  * </p>
  */
-public class DefaultView extends ViewPanel implements WindowListener, ComponentListener
-{
-	private static final long serialVersionUID = - 4489484861592064398L;
+public class DefaultView extends ViewPanel implements WindowListener, ComponentListener {
+	private static final long serialVersionUID = -4489484861592064398L;
 
 	/**
 	 * Parent viewer.
@@ -134,11 +135,11 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 	/**
 	 * The graph renderer.
 	 */
-	protected GraphRenderer renderer;
+	protected SwingGraphRenderer renderer;
 
 	// Construction
 
-	public DefaultView(Viewer viewer, String identifier, GraphRenderer renderer) {
+	public DefaultView(Viewer viewer, String identifier, SwingGraphRenderer renderer) {
 		super(identifier);
 
 		this.viewer = viewer;
@@ -156,16 +157,14 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 
 	// Command
 
-
 	public Camera getCamera() {
 		return renderer.getCamera();
 	}
 
-
 	public void display(GraphicGraph graph, boolean graphChanged) {
 		repaint();
 	}
-	
+
 	@Override
 	public void paintComponent(Graphics g) {
 		super.paintComponent(g);
@@ -194,11 +193,11 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 	public void close(GraphicGraph graph) {
 		renderer.close();
 		graph.addAttribute("ui.viewClosed", getId());
-	
+
 		removeKeyListener(shortcuts);
 		shortcuts.release();
 		mouseClicks.release();
-		
+
 		openInAFrame(false);
 	}
 
@@ -285,12 +284,8 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 		case EXIT:
 			System.exit(0);
 		default:
-			throw new RuntimeException(
-					String
-							.format(
-									"The %s view is not up to date, do not know %s CloseFramePolicy.",
-									getClass().getName(), viewer
-											.getCloseFramePolicy()));
+			throw new RuntimeException(String.format("The %s view is not up to date, do not know %s CloseFramePolicy.",
+					getClass().getName(), viewer.getCloseFramePolicy()));
 		}
 	}
 
@@ -311,23 +306,21 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 		repaint();
 	}
 
- 	public void componentMoved(ComponentEvent e) {
+	public void componentMoved(ComponentEvent e) {
 		repaint();
- 	}
+	}
 
- 	public void componentResized(ComponentEvent e) {
+	public void componentResized(ComponentEvent e) {
 		repaint();
- 	}
+	}
 
- 	public void componentShown(ComponentEvent e) {
- 		repaint();
- 	}
-
+	public void componentShown(ComponentEvent e) {
+		repaint();
+	}
 
 	// Methods deferred to the renderer
 
-	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1,
-			double x2, double y2) {
+	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2) {
 		return renderer.allNodesOrSpritesIn(x1, y1, x2, y2);
 	}
 
@@ -347,44 +340,44 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 	}
 
 	public void freezeElement(GraphicElement element, boolean frozen) {
-		if(frozen) {
+		if (frozen) {
 			element.addAttribute("layout.frozen");
 		} else {
 			element.removeAttribute("layout.frozen");
 		}
 	}
 
-	public void setBackLayerRenderer(LayerRenderer renderer) {
+	public void setBackLayerRenderer(LayerRenderer<Graphics2D> renderer) {
 		this.renderer.setBackLayerRenderer(renderer);
 		repaint();
 	}
 
-	public void setForeLayoutRenderer(LayerRenderer renderer) {
+	public void setForeLayoutRenderer(LayerRenderer<Graphics2D> renderer) {
 		this.renderer.setForeLayoutRenderer(renderer);
 		repaint();
 	}
 
 	public void setMouseManager(MouseManager manager) {
-		if(mouseClicks != null)
+		if (mouseClicks != null)
 			mouseClicks.release();
-		
-		if(manager == null)
+
+		if (manager == null)
 			manager = new DefaultMouseManager();
 
 		manager.init(graph, this);
-		
+
 		mouseClicks = manager;
 	}
 
 	public void setShortcutManager(ShortcutManager manager) {
-		if(shortcuts != null)
+		if (shortcuts != null)
 			shortcuts.release();
-		
-		if(manager == null)
+
+		if (manager == null)
 			manager = new DefaultShortcutManager();
-		
+
 		manager.init(graph, this);
-		
+
 		shortcuts = manager;
 	}
 }

--- a/src/org/graphstream/ui/swingViewer/SwingGraphRenderer.java
+++ b/src/org/graphstream/ui/swingViewer/SwingGraphRenderer.java
@@ -31,45 +31,11 @@
  */
 package org.graphstream.ui.swingViewer;
 
-import org.graphstream.ui.graphicGraph.GraphicGraph;
-
+import java.awt.Container;
 import java.awt.Graphics2D;
 
-/**
- * A specific rendering class that can be plugged in any view and is called to
- * draw under or above the graph.
- * 
- * @see org.graphstream.ui.view.View#setForeLayoutRenderer(LayerRenderer)
- * @see org.graphstream.ui.view.View#setBackLayerRenderer(LayerRenderer)
- */
-public interface LayerRenderer {
-	/**
-	 * Render something under or above the graph.
-	 * 
-	 * @param graphics
-	 *            The Swing graphics.
-	 * @param graph
-	 *            The graphic representation of the graph.
-	 * @param px2Gu
-	 *            The ratio to pass from pixels to graph units.
-	 * @param widthPx
-	 *            The width in pixels of the view port.
-	 * @param heightPx
-	 *            The height in pixels of the view port.
-	 * @param minXGu
-	 *            The minimum visible point abscissa of the graph in graph
-	 *            units.
-	 * @param minYGu
-	 *            The minimum visible point ordinate of the graph in graph
-	 *            units.
-	 * @param maxXGu
-	 *            The maximum visible point abscissa of the graph in graph
-	 *            units.
-	 * @param maxYGu
-	 *            The maximum visible point ordinate of the graph in graph
-	 *            units.
-	 */
-	void render(Graphics2D graphics, GraphicGraph graph, double px2Gu,
-			int widthPx, int heightPx, double minXGu, double minYGu,
-			double maxXGu, double maxYGu);
+import org.graphstream.ui.view.GraphRenderer;
+
+public interface SwingGraphRenderer extends GraphRenderer<Container, Graphics2D> {
+
 }

--- a/src/org/graphstream/ui/swingViewer/SwingGraphRendererBase.java
+++ b/src/org/graphstream/ui/swingViewer/SwingGraphRendererBase.java
@@ -31,51 +31,40 @@
  */
 package org.graphstream.ui.swingViewer;
 
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Graphics2D;
+
+import org.graphstream.ui.view.GraphRendererBase;
 import org.graphstream.ui.view.View;
+import org.graphstream.ui.view.Viewer;
 
-import javax.swing.JPanel;
+public abstract class SwingGraphRendererBase extends GraphRendererBase<Container, Graphics2D>
+		implements SwingGraphRenderer {
 
-/**
- * A view on a graphic graph.
- * 
- * Basically a view is a Swing panel where a
- * {@link org.graphstream.ui.view.GraphRenderer} renders the graphic graph. If
- * you are in the Swing thread, you can change the view on the graphic graph
- * using methods to translate, zoom and rotate the view.
- */
-public abstract class ViewPanel extends JPanel implements View {
-	private static final long serialVersionUID = 4372240131578395549L;
+	// Utilities
 
-	/**
-	 * The view identifier.
-	 */
-	private final String id;
-
-	/**
-	 * New view.
-	 *
-	 * @param identifier
-	 *            The view unique identifier.
-	 */
-	public ViewPanel(final String identifier) {
-		if (null == identifier || identifier.isEmpty()) {
-			throw new IllegalArgumentException("View id cannot be null/empty.");
-		}
-		id = identifier;
+	public View createDefaultView(Viewer viewer, String viewId) {
+		return new DefaultView(viewer, viewId, this);
 	}
 
-	public String getId() {
-		return id;
+	protected void displayNothingToDo(Graphics2D g, int w, int h) {
+		String msg1 = "Graph width/height/depth is zero !!";
+		String msg2 = "Place components using the 'xyz' attribute.";
+
+		g.setColor(Color.RED);
+		g.drawLine(0, 0, w, h);
+		g.drawLine(0, h, w, 0);
+
+		double msg1length = g.getFontMetrics().stringWidth(msg1);
+		double msg2length = g.getFontMetrics().stringWidth(msg2);
+
+		double x = w / 2;
+		double y = h / 2;
+
+		g.setColor(Color.BLACK);
+		g.drawString(msg1, (float) (x - msg1length / 2), (float) (y - 20));
+		g.drawString(msg2, (float) (x - msg2length / 2), (float) (y + 20));
 	}
 
-	/**
-	 * Set the size of the view frame, if any. If this view has been open in a
-	 * frame, this changes the size of the frame containing it.
-	 *
-	 * @param width
-	 *            The new width.
-	 * @param height
-	 *            The new height.
-	 */
-	public abstract void resizeFrame(int width, int height);
 }

--- a/src/org/graphstream/ui/swingViewer/basicRenderer/SwingBasicGraphRenderer.java
+++ b/src/org/graphstream/ui/swingViewer/basicRenderer/SwingBasicGraphRenderer.java
@@ -40,12 +40,12 @@ import org.graphstream.ui.graphicGraph.StyleGroupSet;
 import org.graphstream.ui.graphicGraph.stylesheet.StyleConstants;
 import org.graphstream.ui.graphicGraph.stylesheet.StyleConstants.FillMode;
 import org.graphstream.ui.graphicGraph.stylesheet.Value;
-import org.graphstream.ui.swingViewer.GraphRendererBase;
-import org.graphstream.ui.swingViewer.LayerRenderer;
+import org.graphstream.ui.swingViewer.SwingGraphRendererBase;
 import org.graphstream.ui.swingViewer.util.DefaultCamera;
 import org.graphstream.ui.swingViewer.util.GraphMetrics;
 import org.graphstream.ui.swingViewer.util.Graphics2DOutput;
 import org.graphstream.ui.view.Camera;
+import org.graphstream.ui.view.LayerRenderer;
 
 import javax.imageio.ImageIO;
 import java.awt.BasicStroke;
@@ -80,9 +80,9 @@ import java.util.logging.Logger;
  * 
  * TODO - Les sprites. - Les bordures.
  */
-public class SwingBasicGraphRenderer extends GraphRendererBase {
+public class SwingBasicGraphRenderer extends SwingGraphRendererBase {
 
-    private static final Logger logger = Logger.getLogger(SwingBasicGraphRenderer.class.getName());
+	private static final Logger logger = Logger.getLogger(SwingBasicGraphRenderer.class.getName());
 
 	// Attribute
 
@@ -97,9 +97,9 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 
 	protected SpriteRenderer spriteRenderer = new SpriteRenderer();
 
-	protected LayerRenderer backRenderer = null;
+	protected LayerRenderer<Graphics2D> backRenderer = null;
 
-	protected LayerRenderer foreRenderer = null;
+	protected LayerRenderer<Graphics2D> foreRenderer = null;
 
 	protected PrintStream fpsLog = null;
 
@@ -114,12 +114,23 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 	public SwingBasicGraphRenderer() {
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.graphstream.ui.view.GraphRendererBase#open(org.graphstream.ui.
+	 * graphicGraph.GraphicGraph, java.lang.Object)
+	 */
 	@Override
 	public void open(GraphicGraph graph, Container renderingSurface) {
 		super.open(graph, renderingSurface);
 		camera = new DefaultCamera(graph);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.graphstream.ui.view.GraphRendererBase#close()
+	 */
 	@Override
 	public void close() {
 		if (fpsLog != null) {
@@ -138,8 +149,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 		return camera;
 	}
 
-	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1,
-			double x2, double y2) {
+	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2) {
 		return camera.allNodesOrSpritesIn(graph, x1, y1, x2, y2);
 	}
 
@@ -156,8 +166,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 		if (graph != null && g != null && camera != null) {
 			beginFrame();
 
-			if (camera.getGraphViewport() == null
-					&& camera.getMetrics().diagonal == 0
+			if (camera.getGraphViewport() == null && camera.getMetrics().diagonal == 0
 					&& (graph.getNodeCount() == 0 && graph.getSpriteCount() == 0)) {
 				displayNothingToDo(g, width, height);
 			} else {
@@ -198,8 +207,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 	}
 
 	public void moveElementAtPx(GraphicElement element, double x, double y) {
-		Point3 p = camera.transformPxToGu(camera.getMetrics().viewport[0] + x,
-				camera.getMetrics().viewport[1] + y);
+		Point3 p = camera.transformPxToGu(camera.getMetrics().viewport[0] + x, camera.getMetrics().viewport[1] + y);
 		element.move(p.x, p.y, element.getZ());
 	}
 
@@ -214,15 +222,13 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 		camera.pushView(graph, g);
 		renderGraphElements(g);
 
-		if (style.getStrokeMode() != StyleConstants.StrokeMode.NONE
-				&& style.getStrokeWidth().value != 0) {
+		if (style.getStrokeMode() != StyleConstants.StrokeMode.NONE && style.getStrokeWidth().value != 0) {
 			GraphMetrics metrics = camera.getMetrics();
 			Rectangle2D rect = new Rectangle2D.Double();
 			double px1 = metrics.px1;
 			Value stroke = style.getShadowWidth();
 
-			rect.setFrame(metrics.lo.x, metrics.lo.y + px1,
-					metrics.size.data[0] - px1, metrics.size.data[1] - px1);
+			rect.setFrame(metrics.lo.x, metrics.lo.y + px1, metrics.size.data[0] - px1, metrics.size.data[1] - px1);
 			g.setStroke(new BasicStroke((float) metrics.lengthToGu(stroke)));
 			g.setColor(graph.getStyle().getStrokeColor(0));
 			g.draw(rect);
@@ -234,37 +240,24 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 
 	protected void setupGraphics(Graphics2D g) {
 		if (graph.hasAttribute("ui.antialias")) {
-			g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL,
-					RenderingHints.VALUE_STROKE_PURE);
-			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-					RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-					RenderingHints.VALUE_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		} else {
-			g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL,
-					RenderingHints.VALUE_STROKE_DEFAULT);
-			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
-					RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-					RenderingHints.VALUE_ANTIALIAS_OFF);
+			g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_DEFAULT);
+			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 		}
 
 		if (graph.hasAttribute("ui.quality")) {
-			g.setRenderingHint(RenderingHints.KEY_RENDERING,
-					RenderingHints.VALUE_RENDER_SPEED);
-			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-					RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-			g.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING,
-					RenderingHints.VALUE_COLOR_RENDER_SPEED);
-			g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
-					RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
+			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+			g.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_SPEED);
+			g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
 		} else {
-			g.setRenderingHint(RenderingHints.KEY_RENDERING,
-					RenderingHints.VALUE_RENDER_QUALITY);
-			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-					RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-			g.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING,
-					RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+			g.setRenderingHint(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
 			g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
 					RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
 		}
@@ -281,8 +274,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 
 		if (group.getFillMode() != FillMode.NONE) {
 			g.setColor(group.getFillColor(0));
-			g.fillRect(0, 0, (int) camera.getMetrics().viewport[2],
-					(int) camera.getMetrics().viewport[3]);
+			g.fillRect(0, 0, (int) camera.getMetrics().viewport[2], (int) camera.getMetrics().viewport[3]);
 		}
 	}
 
@@ -338,8 +330,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 	}
 
 	protected void renderSelection(Graphics2D g) {
-		if (selection != null && selection.x1 != selection.x2
-				&& selection.y1 != selection.y2) {
+		if (selection != null && selection.x1 != selection.x2 && selection.y1 != selection.y2) {
 			double x1 = selection.x1;
 			double y1 = selection.y1;
 			double x2 = selection.x2;
@@ -386,13 +377,11 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 			renderLayer(g, foreRenderer);
 	}
 
-	protected void renderLayer(Graphics2D g, LayerRenderer renderer) {
+	protected void renderLayer(Graphics2D g, LayerRenderer<Graphics2D> renderer) {
 		GraphMetrics metrics = camera.getMetrics();
 
-		renderer.render(g, graph, metrics.ratioPx2Gu,
-				(int) metrics.viewport[2], (int) metrics.viewport[3],
-				metrics.loVisible.x, metrics.loVisible.y, metrics.hiVisible.x,
-				metrics.hiVisible.y);
+		renderer.render(g, graph, metrics.ratioPx2Gu, (int) metrics.viewport[2], (int) metrics.viewport[3],
+				metrics.loVisible.x, metrics.loVisible.y, metrics.hiVisible.x, metrics.hiVisible.y);
 	}
 
 	// Utility | Debug
@@ -418,22 +407,18 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 		g.setColor(Color.BLUE);
 		Ellipse2D ellipse = new Ellipse2D.Double();
 		double px1 = metrics.px1;
-		ellipse.setFrame(camera.getViewCenter().x - 3 * px1,
-				camera.getViewCenter().y - 3 * px1, px1 * 6, px1 * 6);
+		ellipse.setFrame(camera.getViewCenter().x - 3 * px1, camera.getViewCenter().y - 3 * px1, px1 * 6, px1 * 6);
 		g.fill(ellipse);
-		ellipse.setFrame(metrics.lo.x - 3 * px1, metrics.lo.y - 3 * px1,
-				px1 * 6, px1 * 6);
+		ellipse.setFrame(metrics.lo.x - 3 * px1, metrics.lo.y - 3 * px1, px1 * 6, px1 * 6);
 		g.fill(ellipse);
-		ellipse.setFrame(metrics.hi.x - 3 * px1, metrics.hi.y - 3 * px1,
-				px1 * 6, px1 * 6);
+		ellipse.setFrame(metrics.hi.x - 3 * px1, metrics.hi.y - 3 * px1, px1 * 6, px1 * 6);
 		g.fill(ellipse);
 	}
 
 	public void screenshot(String filename, int width, int height) {
 		if (graph != null) {
 			if (filename.endsWith("png") || filename.endsWith("PNG")) {
-				BufferedImage img = new BufferedImage(width, height,
-						BufferedImage.TYPE_INT_ARGB);
+				BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 				renderGraph(img.createGraphics());
 
 				File file = new File(filename);
@@ -443,8 +428,7 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 					e.printStackTrace();
 				}
 			} else if (filename.endsWith("bmp") || filename.endsWith("BMP")) {
-				BufferedImage img = new BufferedImage(width, height,
-						BufferedImage.TYPE_INT_RGB);
+				BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 				renderGraph(img.createGraphics());
 
 				File file = new File(filename);
@@ -453,10 +437,9 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 				} catch (Exception e) {
 					e.printStackTrace();
 				}
-			} else if (filename.endsWith("jpg") || filename.endsWith("JPG")
-					|| filename.endsWith("jpeg") || filename.endsWith("JPEG")) {
-				BufferedImage img = new BufferedImage(width, height,
-						BufferedImage.TYPE_INT_RGB);
+			} else if (filename.endsWith("jpg") || filename.endsWith("JPG") || filename.endsWith("jpeg")
+					|| filename.endsWith("JPEG")) {
+				BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
 				renderGraph(img.createGraphics());
 
 				File file = new File(filename);
@@ -473,32 +456,30 @@ public class SwingBasicGraphRenderer extends GraphRendererBase {
 					if (o instanceof Graphics2DOutput) {
 						Graphics2DOutput out = (Graphics2DOutput) o;
 						Graphics2D g2 = out.getGraphics();
-						render(g2, (int) camera.getMetrics().viewport[0],
-								(int) camera.getMetrics().viewport[1],
-								(int) camera.getMetrics().viewport[2],
-								(int) camera.getMetrics().viewport[3]);
+						render(g2, (int) camera.getMetrics().viewport[0], (int) camera.getMetrics().viewport[1],
+								(int) camera.getMetrics().viewport[2], (int) camera.getMetrics().viewport[3]);
 						out.outputTo(filename);
 					} else {
-                        logger.warning(String.format("Plugin %s is not an instance of Graphics2DOutput (%s).", plugin, o.getClass().getName()));
+						logger.warning(String.format("Plugin %s is not an instance of Graphics2DOutput (%s).", plugin,
+								o.getClass().getName()));
 					}
 				} catch (Exception e) {
-                    logger.log(Level.WARNING, "Unexpected error during screen shot.", e);
+					logger.log(Level.WARNING, "Unexpected error during screen shot.", e);
 				}
 			}
 		}
 	}
 
-	public void setBackLayerRenderer(LayerRenderer renderer) {
+	public void setBackLayerRenderer(LayerRenderer<Graphics2D> renderer) {
 		backRenderer = renderer;
 	}
 
-	public void setForeLayoutRenderer(LayerRenderer renderer) {
+	public void setForeLayoutRenderer(LayerRenderer<Graphics2D> renderer) {
 		foreRenderer = renderer;
 	}
 
 	// Style Group Listener
 
-	public void elementStyleChanged(Element element, StyleGroup oldStyle,
-			StyleGroup style) {
+	public void elementStyleChanged(Element element, StyleGroup oldStyle, StyleGroup style) {
 	}
 }

--- a/src/org/graphstream/ui/view/GraphRenderer.java
+++ b/src/org/graphstream/ui/view/GraphRenderer.java
@@ -29,14 +29,11 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
-package org.graphstream.ui.swingViewer;
+package org.graphstream.ui.view;
 
 import org.graphstream.ui.graphicGraph.GraphicElement;
 import org.graphstream.ui.graphicGraph.GraphicGraph;
-import org.graphstream.ui.view.Camera;
 
-import java.awt.Container;
-import java.awt.Graphics2D;
 import java.util.Collection;
 
 /**
@@ -55,21 +52,23 @@ import java.util.Collection;
  * The viewer mechanisms uses graph renderers.
  * </p>
  */
-public interface GraphRenderer {
+public interface GraphRenderer<S, G> {
 	// Initialisation
 
-	void open(GraphicGraph graph, Container drawingSurface);
+	void open(GraphicGraph graph, S drawingSurface);
 
 	void close();
 
 	// Access
+
+	View createDefaultView(Viewer viewer, String id);
 
 	/**
 	 * Get a camera object to provide control commands on the view.
 	 * 
 	 * @return a Camera instance
 	 */
-	public abstract Camera getCamera();
+	Camera getCamera();
 
 	/**
 	 * Search for the first node or sprite (in that order) that contains the
@@ -82,7 +81,7 @@ public interface GraphRenderer {
 	 * @return The first node or sprite at the given coordinates or null if
 	 *         nothing found.
 	 */
-	public abstract GraphicElement findNodeOrSpriteAt(double x, double y);
+	GraphicElement findNodeOrSpriteAt(double x, double y);
 
 	/**
 	 * Search for all the nodes and sprites contained inside the rectangle
@@ -98,15 +97,14 @@ public interface GraphRenderer {
 	 *            The rectangle highest point ordinate.
 	 * @return The set of sprites and nodes in the given rectangle.
 	 */
-	public abstract Collection<GraphicElement> allNodesOrSpritesIn(double x1,
-			double y1, double x2, double y2);
+	Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2);
 
 	// Command
 
 	/**
 	 * Redisplay or update the graph.
 	 */
-	public abstract void render(Graphics2D g, int x, int y, int width, int height);
+	void render(G g, int x, int y, int width, int height);
 
 	/**
 	 * Called by the mouse manager to specify where a node and sprite selection
@@ -117,7 +115,7 @@ public interface GraphRenderer {
 	 * @param y1
 	 *            The selection start ordinate.
 	 */
-	public abstract void beginSelectionAt(double x1, double y1);
+	void beginSelectionAt(double x1, double y1);
 
 	/**
 	 * The selection already started grows toward position (x, y).
@@ -127,7 +125,7 @@ public interface GraphRenderer {
 	 * @param y
 	 *            The new end selection ordinate.
 	 */
-	public abstract void selectionGrowsAt(double x, double y);
+	void selectionGrowsAt(double x, double y);
 
 	/**
 	 * Called by the mouse manager to specify where a node and spite selection
@@ -138,7 +136,7 @@ public interface GraphRenderer {
 	 * @param y2
 	 *            The selection stop ordinate.
 	 */
-	public abstract void endSelectionAt(double x2, double y2);
+	void endSelectionAt(double x2, double y2);
 
 	/**
 	 * Force an element to move at the given location in pixels.
@@ -150,10 +148,9 @@ public interface GraphRenderer {
 	 * @param y
 	 *            The requested position ordinate in pixels.
 	 */
-	public abstract void moveElementAtPx(GraphicElement element, double x,
-			double y);
-	
-	public abstract void screenshot(String filename, int width, int height);
+	void moveElementAtPx(GraphicElement element, double x, double y);
+
+	void screenshot(String filename, int width, int height);
 
 	/**
 	 * Set a layer renderer that will be called each time the graph needs to be
@@ -163,7 +160,7 @@ public interface GraphRenderer {
 	 * @param renderer
 	 *            The renderer (or null to remove it).
 	 */
-	public abstract void setBackLayerRenderer(LayerRenderer renderer);
+	void setBackLayerRenderer(LayerRenderer<G> renderer);
 
 	/**
 	 * Set a layer renderer that will be called each time the graph needs to be
@@ -173,5 +170,5 @@ public interface GraphRenderer {
 	 * @param renderer
 	 *            The renderer (or null to remove it).
 	 */
-	public abstract void setForeLayoutRenderer(LayerRenderer renderer);
+	void setForeLayoutRenderer(LayerRenderer<G> renderer);
 }

--- a/src/org/graphstream/ui/view/GraphRendererBase.java
+++ b/src/org/graphstream/ui/view/GraphRendererBase.java
@@ -29,17 +29,12 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
-package org.graphstream.ui.swingViewer;
+package org.graphstream.ui.view;
 
 import org.graphstream.ui.graphicGraph.GraphicGraph;
 import org.graphstream.ui.graphicGraph.StyleGroupListener;
-import org.graphstream.ui.view.Selection;
 
-import java.awt.Color;
-import java.awt.Container;
-import java.awt.Graphics2D;
-
-public abstract class GraphRendererBase implements GraphRenderer,
+public abstract class GraphRendererBase<S, G> implements GraphRenderer<S, G>,
 		StyleGroupListener {
 	// Attribute
 
@@ -56,11 +51,11 @@ public abstract class GraphRendererBase implements GraphRenderer,
 	/**
 	 * The surface we are rendering on (used only
 	 */
-	protected Container renderingSurface;
+	protected S renderingSurface;
 
 	// Initialisation
 
-	public void open(GraphicGraph graph, Container renderingSurface) {
+	public void open(GraphicGraph graph, S renderingSurface) {
 		if (this.graph != null)
 			throw new RuntimeException(
 					"renderer already open, cannot open twice");
@@ -80,7 +75,7 @@ public abstract class GraphRendererBase implements GraphRenderer,
 
 	// Access
 
-	public Container getRenderingSurface() {
+	public S getRenderingSurface() {
 		return renderingSurface;
 	}
 
@@ -103,26 +98,5 @@ public abstract class GraphRendererBase implements GraphRenderer,
 
 	public void endSelectionAt(double x2, double y2) {
 		selection = null;
-	}
-
-	// Utilities
-
-	protected void displayNothingToDo(Graphics2D g, int w, int h) {
-		String msg1 = "Graph width/height/depth is zero !!";
-		String msg2 = "Place components using the 'xyz' attribute.";
-
-		g.setColor(Color.RED);
-		g.drawLine(0, 0, w, h);
-		g.drawLine(0, h, w, 0);
-
-		double msg1length = g.getFontMetrics().stringWidth(msg1);
-		double msg2length = g.getFontMetrics().stringWidth(msg2);
-
-		double x = w / 2;
-		double y = h / 2;
-
-		g.setColor(Color.BLACK);
-		g.drawString(msg1, (float)(x - msg1length / 2), (float)(y - 20));
-		g.drawString(msg2, (float)(x - msg2length / 2), (float)(y + 20));
 	}
 }

--- a/src/org/graphstream/ui/view/LayerRenderer.java
+++ b/src/org/graphstream/ui/view/LayerRenderer.java
@@ -29,53 +29,45 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
-package org.graphstream.ui.swingViewer;
+package org.graphstream.ui.view;
 
-import org.graphstream.ui.view.View;
-
-import javax.swing.JPanel;
+import org.graphstream.ui.graphicGraph.GraphicGraph;
 
 /**
- * A view on a graphic graph.
+ * A specific rendering class that can be plugged in any view and is called to
+ * draw under or above the graph.
  * 
- * Basically a view is a Swing panel where a
- * {@link org.graphstream.ui.view.GraphRenderer} renders the graphic graph. If
- * you are in the Swing thread, you can change the view on the graphic graph
- * using methods to translate, zoom and rotate the view.
+ * @see org.graphstream.ui.view.View#setForeLayoutRenderer(LayerRenderer)
+ * @see org.graphstream.ui.view.View#setBackLayerRenderer(LayerRenderer)
  */
-public abstract class ViewPanel extends JPanel implements View {
-	private static final long serialVersionUID = 4372240131578395549L;
-
+public interface LayerRenderer<G> {
 	/**
-	 * The view identifier.
+	 * Render something under or above the graph.
+	 * 
+	 * @param graphics
+	 *            The graphics module used to draw (Graphics2D for example, when
+	 *            using Swing).
+	 * @param graph
+	 *            The graphic representation of the graph.
+	 * @param px2Gu
+	 *            The ratio to pass from pixels to graph units.
+	 * @param widthPx
+	 *            The width in pixels of the view port.
+	 * @param heightPx
+	 *            The height in pixels of the view port.
+	 * @param minXGu
+	 *            The minimum visible point abscissa of the graph in graph
+	 *            units.
+	 * @param minYGu
+	 *            The minimum visible point ordinate of the graph in graph
+	 *            units.
+	 * @param maxXGu
+	 *            The maximum visible point abscissa of the graph in graph
+	 *            units.
+	 * @param maxYGu
+	 *            The maximum visible point ordinate of the graph in graph
+	 *            units.
 	 */
-	private final String id;
-
-	/**
-	 * New view.
-	 *
-	 * @param identifier
-	 *            The view unique identifier.
-	 */
-	public ViewPanel(final String identifier) {
-		if (null == identifier || identifier.isEmpty()) {
-			throw new IllegalArgumentException("View id cannot be null/empty.");
-		}
-		id = identifier;
-	}
-
-	public String getId() {
-		return id;
-	}
-
-	/**
-	 * Set the size of the view frame, if any. If this view has been open in a
-	 * frame, this changes the size of the frame containing it.
-	 *
-	 * @param width
-	 *            The new width.
-	 * @param height
-	 *            The new height.
-	 */
-	public abstract void resizeFrame(int width, int height);
+	void render(G graphics, GraphicGraph graph, double px2Gu, int widthPx, int heightPx, double minXGu, double minYGu,
+			double maxXGu, double maxYGu);
 }

--- a/src/org/graphstream/ui/view/View.java
+++ b/src/org/graphstream/ui/view/View.java
@@ -44,168 +44,207 @@ import java.util.Collection;
 /**
  * A view on a graphic graph.
  */
-public interface View
-{
-    /**
-     * Get the unique view id.
-     *
-     * @return a view id
-     */
-    String getId();
+public interface View {
+	/**
+	 * Get the unique view id.
+	 *
+	 * @return a view id
+	 */
+	String getId();
 
-    /**
-     * Get a camera object to provide control commands on the view.
-     *
-     * @return a Camera instance
-     */
-    Camera getCamera();
+	/**
+	 * Get a camera object to provide control commands on the view.
+	 *
+	 * @return a Camera instance
+	 */
+	Camera getCamera();
 
-    /**
-     * Search for the first node or sprite (in that order) that contains the
-     * point at coordinates (x, y).
-     *
-     * @param x The point abscissa.
-     * @param y The point ordinate.
-     * @return The first node or sprite at the given coordinates or null if
-     * nothing found.
-     */
-    GraphicElement findNodeOrSpriteAt(double x, double y);
+	/**
+	 * Search for the first node or sprite (in that order) that contains the
+	 * point at coordinates (x, y).
+	 *
+	 * @param x
+	 *            The point abscissa.
+	 * @param y
+	 *            The point ordinate.
+	 * @return The first node or sprite at the given coordinates or null if
+	 *         nothing found.
+	 */
+	GraphicElement findNodeOrSpriteAt(double x, double y);
 
-    /**
-     * Search for all the nodes and sprites contained inside the rectangle
-     * (x1,y1)-(x2,y2).
-     *
-     * @param x1 The rectangle lowest point abscissa.
-     * @param y1 The rectangle lowest point ordinate.
-     * @param x2 The rectangle highest point abscissa.
-     * @param y2 The rectangle highest point ordinate.
-     * @return The set of sprites and nodes in the given rectangle.
-     */
-    Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2);
+	/**
+	 * Search for all the nodes and sprites contained inside the rectangle
+	 * (x1,y1)-(x2,y2).
+	 *
+	 * @param x1
+	 *            The rectangle lowest point abscissa.
+	 * @param y1
+	 *            The rectangle lowest point ordinate.
+	 * @param x2
+	 *            The rectangle highest point abscissa.
+	 * @param y2
+	 *            The rectangle highest point ordinate.
+	 * @return The set of sprites and nodes in the given rectangle.
+	 */
+	Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2);
 
-    /**
-     * Redisplay or update the view contents. Called by the Viewer.
-     *
-     * @param graph        The graphic graph to represent.
-     * @param graphChanged True if the graph changed since the last call to this method.
-     */
-    void display(GraphicGraph graph, boolean graphChanged);
+	/**
+	 * Redisplay or update the view contents. Called by the Viewer.
+	 *
+	 * @param graph
+	 *            The graphic graph to represent.
+	 * @param graphChanged
+	 *            True if the graph changed since the last call to this method.
+	 */
+	void display(GraphicGraph graph, boolean graphChanged);
 
-    /**
-     * Close definitively this view. Called by the Viewer.
-     *
-     * @param graph The graphic graph.
-     */
-    void close(GraphicGraph graph);
+	/**
+	 * Open this view in a frame. The argument allows to put the view in a new
+	 * frame or to remove it from the frame (if it already exists). Called by
+	 * the Viewer.
+	 *
+	 * @param on
+	 *            Add the view in its own frame or remove it if it already was
+	 *            in its own frame.
+	 */
+	void openInAFrame(boolean on);
 
+	/**
+	 * Close definitively this view. Called by the Viewer.
+	 *
+	 * @param graph
+	 *            The graphic graph.
+	 */
+	void close(GraphicGraph graph);
 
-    /**
-     * Called by the mouse manager to specify where a node and sprite selection
-     * started.
-     *
-     * @param x1 The selection start abscissa.
-     * @param y1 The selection start ordinate.
-     */
-    void beginSelectionAt(double x1, double y1);
+	/**
+	 * Called by the mouse manager to specify where a node and sprite selection
+	 * started.
+	 *
+	 * @param x1
+	 *            The selection start abscissa.
+	 * @param y1
+	 *            The selection start ordinate.
+	 */
+	void beginSelectionAt(double x1, double y1);
 
-    /**
-     * The selection already started grows toward position (x, y).
-     *
-     * @param x The new end selection abscissa.
-     * @param y The new end selection ordinate.
-     */
-    void selectionGrowsAt(double x, double y);
+	/**
+	 * The selection already started grows toward position (x, y).
+	 *
+	 * @param x
+	 *            The new end selection abscissa.
+	 * @param y
+	 *            The new end selection ordinate.
+	 */
+	void selectionGrowsAt(double x, double y);
 
-    /**
-     * Called by the mouse manager to specify where a node and spite selection
-     * stopped.
-     *
-     * @param x2 The selection stop abscissa.
-     * @param y2 The selection stop ordinate.
-     */
-    void endSelectionAt(double x2, double y2);
+	/**
+	 * Called by the mouse manager to specify where a node and spite selection
+	 * stopped.
+	 *
+	 * @param x2
+	 *            The selection stop abscissa.
+	 * @param y2
+	 *            The selection stop ordinate.
+	 */
+	void endSelectionAt(double x2, double y2);
 
-    /**
-     * Freeze an element so that the optional layout cannot move it.
-     *
-     * @param element The element.
-     * @param frozen  If true the element cannot be moved automatically.
-     */
-    void freezeElement(GraphicElement element, boolean frozen);
+	/**
+	 * Freeze an element so that the optional layout cannot move it.
+	 *
+	 * @param element
+	 *            The element.
+	 * @param frozen
+	 *            If true the element cannot be moved automatically.
+	 */
+	void freezeElement(GraphicElement element, boolean frozen);
 
-    /**
-     * Force an element to move at the given location in pixels.
-     *
-     * @param element The element.
-     * @param x       The requested position abscissa in pixels.
-     * @param y       The requested position ordinate in pixels.
-     */
-    void moveElementAtPx(GraphicElement element, double x, double y);
+	/**
+	 * Force an element to move at the given location in pixels.
+	 *
+	 * @param element
+	 *            The element.
+	 * @param x
+	 *            The requested position abscissa in pixels.
+	 * @param y
+	 *            The requested position ordinate in pixels.
+	 */
+	void moveElementAtPx(GraphicElement element, double x, double y);
 
-    /**
-     * Change the manager for mouse events on this view. If the value for the new manager is
-     * null, a default manager is installed. The {@link org.graphstream.ui.view.util.MouseManager#init(org.graphstream.ui.graphicGraph.GraphicGraph, View)}
-     * method must not yet have been called.
-     *
-     * @param manager The new manager, or null to set the default manager.
-     * @see org.graphstream.ui.view.util.MouseManager
-     */
-    void setMouseManager(MouseManager manager);
+	/**
+	 * Change the manager for mouse events on this view. If the value for the
+	 * new manager is null, a default manager is installed. The
+	 * {@link org.graphstream.ui.view.util.MouseManager#init(org.graphstream.ui.graphicGraph.GraphicGraph, View)}
+	 * method must not yet have been called.
+	 *
+	 * @param manager
+	 *            The new manager, or null to set the default manager.
+	 * @see org.graphstream.ui.view.util.MouseManager
+	 */
+	void setMouseManager(MouseManager manager);
 
-    /**
-     * Change the manager for key and shortcuts events on this view. If the value for the new
-     * manager is null, a default manager is installed. The {@link org.graphstream.ui.view.util.ShortcutManager#init(org.graphstream.ui.graphicGraph.GraphicGraph, View)}
-     * method must not yet have been called.
-     *
-     * @param manager The new manager, or null to set the default manager
-     * @see org.graphstream.ui.view.util.ShortcutManager
-     */
-    void setShortcutManager(ShortcutManager manager);
+	/**
+	 * Change the manager for key and shortcuts events on this view. If the
+	 * value for the new manager is null, a default manager is installed. The
+	 * {@link org.graphstream.ui.view.util.ShortcutManager#init(org.graphstream.ui.graphicGraph.GraphicGraph, View)}
+	 * method must not yet have been called.
+	 *
+	 * @param manager
+	 *            The new manager, or null to set the default manager
+	 * @see org.graphstream.ui.view.util.ShortcutManager
+	 */
+	void setShortcutManager(ShortcutManager manager);
 
-    /**
-     * Request ui focus.
-     */
-    void requestFocus();
+	/**
+	 * Request ui focus.
+	 */
+	void requestFocus();
 
-    /**
-     * Add key ui listener.
-     *
-     * @param l the listener
-     */
-    void addKeyListener(KeyListener l);
+	/**
+	 * Add key ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void addKeyListener(KeyListener l);
 
-    /**
-     * Remove key ui listener.
-     *
-     * @param l the listener
-     */
-    void removeKeyListener(KeyListener l);
+	/**
+	 * Remove key ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void removeKeyListener(KeyListener l);
 
-    /**
-     * Add mouse ui listener.
-     *
-     * @param l the listener
-     */
-    void addMouseListener(MouseListener l);
+	/**
+	 * Add mouse ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void addMouseListener(MouseListener l);
 
-    /**
-     * Remove mouse ui listener.
-     *
-     * @param l the listener
-     */
-    void removeMouseListener(MouseListener l);
+	/**
+	 * Remove mouse ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void removeMouseListener(MouseListener l);
 
-    /**
-     * Add mouse motion ui listener.
-     *
-     * @param l the listener
-     */
-    void addMouseMotionListener(MouseMotionListener l);
+	/**
+	 * Add mouse motion ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void addMouseMotionListener(MouseMotionListener l);
 
-    /**
-     * Remove mouse motion ui listener.
-     *
-     * @param l the listener
-     */
-    void removeMouseMotionListener(MouseMotionListener l);
+	/**
+	 * Remove mouse motion ui listener.
+	 *
+	 * @param l
+	 *            the listener
+	 */
+	void removeMouseMotionListener(MouseMotionListener l);
 }


### PR DESCRIPTION
GraphRenderer takes now two templates, one describing the rendering surface (ie java.awt.Container when using Swing), and the other describing the rendering module (ie Graphics2D for example).