### PR TITLE
Fixed "ClassCastException: java.lang.Double cannot be cast to java.lang.String" in GMLContext.optNodeStyle

### DIFF
--- a/src/org/graphstream/stream/file/gml/GMLContext.java
+++ b/src/org/graphstream/stream/file/gml/GMLContext.java
@@ -353,26 +353,26 @@ public class GMLContext {
 
 		if (kv != null) {
 			StringBuffer style = new StringBuffer();
-			String w = null, h = null, d = null;
+			Object w = null, h = null, d = null;
 			graphics = new Graphics();
 
 			if (kv.get("x") != null) {
-				graphics.setX(asDouble((String) kv.get("x")));
+				graphics.setX(asDouble(kv.get("x")));
 			}
 			if (kv.get("y") != null) {
-				graphics.setY(asDouble((String) kv.get("y")));
+				graphics.setY(asDouble(kv.get("y")));
 			}
 			if (kv.get("z") != null) {
-				graphics.setZ(asDouble((String) kv.get("z")));
+				graphics.setZ(asDouble(kv.get("z")));
 			}
 			if (kv.get("w") != null) {
-				w = (String) kv.get("w");
+				w = kv.get("w");
 			}
 			if (kv.get("h") != null) {
-				h = (String) kv.get("h");
+				h = kv.get("h");
 			}
 			if (kv.get("d") != null) {
-				d = (String) kv.get("d");
+				d = kv.get("d");
 			}
 			if (w != null || h != null || d != null) {
 				int ww = w != null ? (int) asDouble(w) : 0;
@@ -398,17 +398,16 @@ public class GMLContext {
 
 		if (kv != null) {
 			StringBuffer style = new StringBuffer();
-			String w = null;
+			Object w = null;
 			graphics = new Graphics();
 
 			if (kv.get("width") != null) {
-				w = (String) kv.get("width");
+				w = kv.get("width");
 			} else if (kv.get("w") != null) {
-				w = (String) kv.get("w");
+				w = kv.get("w");
 			}
 			if (w != null) {
-				double ww = w != null ? asDouble(w) : 0.0;
-				style.append(String.format("size: %fpx;", ww));
+				style.append(String.format("size: %fpx;", asDouble(w)));
 			}
 			if (kv.get("type") != null) {
 				style.append(String.format("shape: %s; ",
@@ -453,10 +452,16 @@ public class GMLContext {
 		}
 	}
 
-	protected double asDouble(String value) {
-		try {
-			return Double.parseDouble(value);
-		} catch (NumberFormatException e) {
+	protected double asDouble(Object value) {
+		if (value instanceof Number) {
+			return ((Number) value).doubleValue();
+		} else if (value instanceof String) {
+			try {
+				return Double.parseDouble((String) value);
+			} catch (NumberFormatException e) {
+				return 0.0;
+			}
+		} else {
 			return 0.0;
 		}
 	}


### PR DESCRIPTION
This exception always happened while reading GML files. It had stacktrace:
```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String

	at org.graphstream.stream.file.gml.GMLContext.optNodeStyle(GMLContext.java:360)
	at org.graphstream.stream.file.gml.GMLContext.handleNodeAttributes(GMLContext.java:279)
	at org.graphstream.stream.file.gml.GMLContext.handleAddNode(GMLContext.java:160)
	at org.graphstream.stream.file.gml.GMLContext.insertKeyValues(GMLContext.java:90)
	at org.graphstream.stream.file.gml.GMLContext.handleKeyValues(GMLContext.java:63)
	at org.graphstream.stream.file.gml.GMLParser.all(GMLParser.java:138)
	at org.graphstream.stream.file.FileSourceParser.readAll(FileSourceParser.java:115)
       ....
```
Idea of workaround: if KeyValue already returns Double/Integer => do not cast it to String

Example file that failed:
```
graph
[
  Creator "Gephi"
  directed 1
  node
  [
    id 0
    label "a"
  ]
  node
  [
    id 1
    label "b"
    graphics
    [
      x -199.04431
      y 360.95694
      z 0.0
      w 10.0
      h 10.0
      d 10.0
      fill "#000000"
    ]
  ]
  node
  [
    id 2
    label "c"
    graphics
    [
      x -192.9271
      y -263.6634
      z 0.0
      w 10.0
      h 10.0
      d 10.0
      fill "#000000"
    ]
  ]
  node
  [
    id 3
    label "d"
    graphics
    [
      x 345.67603
      y 4.9932384
      z 0.0
      w 10.0
      h 10.0
      d 10.0
      fill "#000000"
    ]
  ]
  edge
  [
    id 0
    source 0
    target 1
    value 1.0
    fill "#000000"
  ]
  edge
  [
    id 1
    source 0
    target 2
    value 1.0
    fill "#000000"
  ]
  edge
  [
    id 2
    source 1
    target 3
    value 1.0
    fill "#000000"
  ]
  edge
  [
    id 3
    source 2
    target 3
    value 1.0
    fill "#000000"
  ]
]
```