### PR TITLE
Fixed two bugs in MouseOver events.

### DIFF
--- a/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
+++ b/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
@@ -80,7 +80,6 @@ public class MouseOverMouseManager extends DefaultMouseManager {
             boolean stayedOnElement = false;
             GraphicElement currentElement = view.findNodeOrSpriteAt(event.getX(), event.getY());
             if (hoveredElement != null) {
-            	System.out.println("An alement is already hovered");
                 stayedOnElement = currentElement == null ? false : currentElement.equals(hoveredElement);
                 if (!stayedOnElement && hoveredElement.hasAttribute("ui.mouseOver")) {
                     mouseLeftElement(hoveredElement);
@@ -93,10 +92,8 @@ public class MouseOverMouseManager extends DefaultMouseManager {
                     hoveredElement = currentElement;
                     hoveredElementLastChanged = event.getWhen();
                     if (latestHoverTimerTask != null) {
-                    	System.out.println("Cancelling timer");
                         latestHoverTimerTask.cancel();
                     }
-                    System.out.println("Starting timer");
                     latestHoverTimerTask = new HoverTimerTask(hoveredElementLastChanged, hoveredElement);
                     hoverTimer.schedule(latestHoverTimerTask, delay);
                 }
@@ -126,7 +123,6 @@ public class MouseOverMouseManager extends DefaultMouseManager {
             try {
                 hoverLock.lock();
                 if (hoveredElementLastChanged == lastChanged) {
-                	System.out.println("Setting element as hovered");
                     mouseOverElement(element);
                 }
             } catch (Exception ex) {

--- a/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
+++ b/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
@@ -70,6 +70,7 @@ public class MouseOverMouseManager extends DefaultMouseManager {
     }
 
     protected void mouseLeftElement(GraphicElement element) {
+    	this.hoveredElement = null;
         element.removeAttribute("ui.mouseOver");
     }
 
@@ -79,7 +80,8 @@ public class MouseOverMouseManager extends DefaultMouseManager {
             boolean stayedOnElement = false;
             GraphicElement currentElement = view.findNodeOrSpriteAt(event.getX(), event.getY());
             if (hoveredElement != null) {
-                stayedOnElement = currentElement.equals(hoveredElement);
+            	System.out.println("An alement is already hovered");
+                stayedOnElement = currentElement == null ? false : currentElement.equals(hoveredElement);
                 if (!stayedOnElement && hoveredElement.hasAttribute("ui.mouseOver")) {
                     mouseLeftElement(hoveredElement);
                 }
@@ -91,8 +93,10 @@ public class MouseOverMouseManager extends DefaultMouseManager {
                     hoveredElement = currentElement;
                     hoveredElementLastChanged = event.getWhen();
                     if (latestHoverTimerTask != null) {
+                    	System.out.println("Cancelling timer");
                         latestHoverTimerTask.cancel();
                     }
+                    System.out.println("Starting timer");
                     latestHoverTimerTask = new HoverTimerTask(hoveredElementLastChanged, hoveredElement);
                     hoverTimer.schedule(latestHoverTimerTask, delay);
                 }
@@ -122,6 +126,7 @@ public class MouseOverMouseManager extends DefaultMouseManager {
             try {
                 hoverLock.lock();
                 if (hoveredElementLastChanged == lastChanged) {
+                	System.out.println("Setting element as hovered");
                     mouseOverElement(element);
                 }
             } catch (Exception ex) {


### PR DESCRIPTION
Hi,

I came across two bugs in the functionality for MouseOverEvents for nodes.

The first one was, that if `currentElement` is `null` in line 82, a NPE was caused.
Furthermore, moving the mouse on a node `a`, then on the empty plane and then back on it did not fired
a new event for the second time moving the cursor over the node.

Both bugs are fixed with this PR.