### PR TITLE
ui.selected attribute not set for edges #140

### DIFF
--- a/src-test/org/graphstream/ui/viewer/test/DemoViewerColorInterpolation.java
+++ b/src-test/org/graphstream/ui/viewer/test/DemoViewerColorInterpolation.java
@@ -128,8 +128,6 @@ public class DemoViewerColorInterpolation implements ViewerListener {
 	protected static String styleSheet = "graph         { padding: 20px; stroke-width: 0px; }"
 			+ "node:selected { fill-color: red;  fill-mode: plain; }"
 			+ "node:clicked  { fill-color: blue; fill-mode: plain; }"
-			+ "edge:selected { fill-color: purple; fill-mode: plain; }"
-			+ "edge:clicked  { fill-color: orange; fill-mode: plain; }"
 			+ "node#A        { fill-color: green, yellow, purple; fill-mode: dyn-plain; }";
 
 	public void buttonPushed(String id) {

--- a/src-test/org/graphstream/ui/viewer/test/DemoViewerEdgeSelection.java
+++ b/src-test/org/graphstream/ui/viewer/test/DemoViewerEdgeSelection.java
@@ -31,45 +31,50 @@
  */
 package org.graphstream.ui.viewer.test;
 
+import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 import org.graphstream.graph.implementations.MultiGraph;
+import org.graphstream.ui.view.Viewer;
 import org.graphstream.ui.view.ViewerListener;
 import org.graphstream.ui.view.ViewerPipe;
+import org.graphstream.ui.view.util.DefaultMouseManager;
+import org.graphstream.ui.view.util.InteractiveElement;
+
+import java.util.EnumSet;
 
 /**
  * Test the viewer.
  */
-public class DemoViewerColorInterpolation implements ViewerListener {
+public class DemoViewerEdgeSelection implements ViewerListener {
 	public static void main(String args[]) {
 		// System.setProperty( "gs.ui.renderer",
 		// "org.graphstream.ui.j2dviewer.J2DGraphRenderer" );
-
-		new DemoViewerColorInterpolation();
+		new DemoViewerEdgeSelection();
 	}
 
 	protected boolean loop = true;
 
-	public DemoViewerColorInterpolation() {
+	public DemoViewerEdgeSelection() {
 		Graph graph = new MultiGraph("main graph");
-		ViewerPipe pipe = graph.display(false).newViewerPipe();
+		Viewer view = graph.display(true);
+		view.getDefaultView().setMouseManager(new DefaultMouseManager(EnumSet.of(InteractiveElement.EDGE, InteractiveElement.NODE, InteractiveElement.SPRITE)));
+		ViewerPipe pipe = view.newViewerPipe();
 
 		// graph.addAttribute( "ui.quality" );
 		graph.addAttribute("ui.antialias");
 
 		pipe.addViewerListener(this);
 
-		Node A = graph.addNode("A");
-		Node B = graph.addNode("B");
-		Node C = graph.addNode("C");
+		for (String nodeId : new String[]{"A", "B", "C"}) {
+			Node node = graph.addNode(nodeId);
+			node.setAttribute("ui.label", nodeId);
 
-		graph.addEdge("AB", "A", "B", true);
+		}
+
+		Edge ab = graph.addEdge("AB", "A", "B", true);
 		graph.addEdge("BC", "B", "C", true);
 		graph.addEdge("CA", "C", "A", true);
-
-		A.addAttribute("xyz", 0, 1, 0);
-		B.addAttribute("xyz", 1, 0, 0);
-		C.addAttribute("xyz", -1, 0, 0);
 
 		graph.addAttribute("ui.stylesheet", styleSheet);
 
@@ -95,7 +100,6 @@ public class DemoViewerColorInterpolation implements ViewerListener {
 				dir = -dir;
 			}
 
-			A.setAttribute("ui.color", color);
 			showSelection(graph);
 		}
 

--- a/src/org/graphstream/ui/swingViewer/DefaultView.java
+++ b/src/org/graphstream/ui/swingViewer/DefaultView.java
@@ -37,10 +37,7 @@ import org.graphstream.ui.view.Viewer;
 import org.graphstream.ui.view.Camera;
 import org.graphstream.ui.view.GraphRenderer;
 import org.graphstream.ui.view.LayerRenderer;
-import org.graphstream.ui.view.util.DefaultMouseManager;
-import org.graphstream.ui.view.util.DefaultShortcutManager;
-import org.graphstream.ui.view.util.MouseManager;
-import org.graphstream.ui.view.util.ShortcutManager;
+import org.graphstream.ui.view.util.*;
 
 import javax.swing.JFrame;
 import java.awt.BorderLayout;
@@ -51,6 +48,7 @@ import java.awt.event.ComponentListener;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 import java.util.Collection;
+import java.util.EnumSet;
 
 /**
  * Base for constructing views.
@@ -320,13 +318,16 @@ public class DefaultView extends ViewPanel implements WindowListener, ComponentL
 
 	// Methods deferred to the renderer
 
-	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2) {
-		return renderer.allNodesOrSpritesIn(x1, y1, x2, y2);
+	@Override
+	public Collection<GraphicElement> allGraphicElementsIn(EnumSet<InteractiveElement> types, double x1, double y1, double x2, double y2) {
+		return renderer.allGraphicElementsIn(types, x1, y1, x2, y2);
 	}
 
-	public GraphicElement findNodeOrSpriteAt(double x, double y) {
-		return renderer.findNodeOrSpriteAt(x, y);
+	@Override
+	public GraphicElement findGraphicElementAt(EnumSet<InteractiveElement> types, double x, double y) {
+		return renderer.findGraphicElementAt(types,x, y);
 	}
+
 
 	public void moveElementAtPx(GraphicElement element, double x, double y) {
 		// The feedback on the node positions is often off since not needed

--- a/src/org/graphstream/ui/swingViewer/basicRenderer/SwingBasicGraphRenderer.java
+++ b/src/org/graphstream/ui/swingViewer/basicRenderer/SwingBasicGraphRenderer.java
@@ -46,6 +46,7 @@ import org.graphstream.ui.swingViewer.util.GraphMetrics;
 import org.graphstream.ui.swingViewer.util.Graphics2DOutput;
 import org.graphstream.ui.view.Camera;
 import org.graphstream.ui.view.LayerRenderer;
+import org.graphstream.ui.view.util.InteractiveElement;
 
 import javax.imageio.ImageIO;
 import java.awt.BasicStroke;
@@ -61,6 +62,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -149,12 +151,14 @@ public class SwingBasicGraphRenderer extends SwingGraphRendererBase {
 		return camera;
 	}
 
-	public Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2) {
-		return camera.allNodesOrSpritesIn(graph, x1, y1, x2, y2);
+	@Override
+	public Collection<GraphicElement> allGraphicElementsIn(EnumSet<InteractiveElement> types, double x1, double y1, double x2, double y2) {
+		return camera.allGraphicElementsIn(graph,types,x1, y1, x2, y2);
 	}
 
-	public GraphicElement findNodeOrSpriteAt(double x, double y) {
-		return camera.findNodeOrSpriteAt(graph, x, y);
+	@Override
+	public GraphicElement findGraphicElementAt(EnumSet<InteractiveElement> types, double x, double y) {
+		return camera.findGraphicElementAt(graph, types, x, y);
 	}
 
 	// Command
@@ -265,7 +269,7 @@ public class SwingBasicGraphRenderer extends SwingGraphRendererBase {
 
 	/**
 	 * Render the background of the graph.
-	 * 
+	 *
 	 * @param g
 	 *            The Swing graphics.
 	 */
@@ -280,7 +284,7 @@ public class SwingBasicGraphRenderer extends SwingGraphRendererBase {
 
 	/**
 	 * Render the element of the graph.
-	 * 
+	 *
 	 * @param g
 	 *            The Swing graphics.
 	 */
@@ -302,7 +306,7 @@ public class SwingBasicGraphRenderer extends SwingGraphRendererBase {
 
 	/**
 	 * Render a style group.
-	 * 
+	 *
 	 * @param g
 	 *            The Swing graphics.
 	 * @param group

--- a/src/org/graphstream/ui/view/Camera.java
+++ b/src/org/graphstream/ui/view/Camera.java
@@ -33,7 +33,12 @@ package org.graphstream.ui.view;
 
 import org.graphstream.ui.geom.Point3;
 import org.graphstream.ui.graphicGraph.GraphicElement;
+import org.graphstream.ui.graphicGraph.GraphicGraph;
 import org.graphstream.ui.swingViewer.util.GraphMetrics;
+import org.graphstream.ui.view.util.InteractiveElement;
+
+import java.util.Collection;
+import java.util.EnumSet;
 
 public interface Camera {
 	/**
@@ -195,4 +200,8 @@ public interface Camera {
 	 * @return True if the element is visible and therefore must be rendered.
 	 */
 	boolean isVisible(GraphicElement element);
+
+    GraphicElement findGraphicElementAt(GraphicGraph graph, EnumSet<InteractiveElement> types, double x, double y);
+
+	Collection<GraphicElement> allGraphicElementsIn(GraphicGraph graph, EnumSet<InteractiveElement> types, double x1, double y1, double x2, double y2);
 }

--- a/src/org/graphstream/ui/view/GraphRenderer.java
+++ b/src/org/graphstream/ui/view/GraphRenderer.java
@@ -33,8 +33,10 @@ package org.graphstream.ui.view;
 
 import org.graphstream.ui.graphicGraph.GraphicElement;
 import org.graphstream.ui.graphicGraph.GraphicGraph;
+import org.graphstream.ui.view.util.InteractiveElement;
 
 import java.util.Collection;
+import java.util.EnumSet;
 
 /**
  * Interface for classes that draw a GraphicGraph in a swing component.
@@ -71,22 +73,26 @@ public interface GraphRenderer<S, G> {
 	Camera getCamera();
 
 	/**
-	 * Search for the first node or sprite (in that order) that contains the
+	 * Search for the first GraphicElement among the specified types (precedence: node, edge, sprite) that contains the
 	 * point at coordinates (x, y).
-	 * 
+	 *
+	 * @param types
+	 * 			  The types to check
 	 * @param x
 	 *            The point abscissa.
 	 * @param y
 	 *            The point ordinate.
-	 * @return The first node or sprite at the given coordinates or null if
+	 * @return The first GraphicElement among the specified types at the given coordinates or null if
 	 *         nothing found.
 	 */
-	GraphicElement findNodeOrSpriteAt(double x, double y);
+	GraphicElement findGraphicElementAt(EnumSet<InteractiveElement> types, double x, double y);
 
 	/**
-	 * Search for all the nodes and sprites contained inside the rectangle
+	 * Search for all the graphic elements of the specified types contained inside the rectangle
 	 * (x1,y1)-(x2,y2).
-	 * 
+	 *
+	 * @param types
+	 * 			  The types to check
 	 * @param x1
 	 *            The rectangle lowest point abscissa.
 	 * @param y1
@@ -95,9 +101,9 @@ public interface GraphRenderer<S, G> {
 	 *            The rectangle highest point abscissa.
 	 * @param y2
 	 *            The rectangle highest point ordinate.
-	 * @return The set of sprites and nodes in the given rectangle.
+	 * @return The set of GraphicElements in the given rectangle.
 	 */
-	Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2);
+	Collection<GraphicElement> allGraphicElementsIn(EnumSet<InteractiveElement> types, double x1, double y1, double x2, double y2);
 
 	// Command
 
@@ -171,4 +177,7 @@ public interface GraphRenderer<S, G> {
 	 *            The renderer (or null to remove it).
 	 */
 	void setForeLayoutRenderer(LayerRenderer<G> renderer);
+
+
+
 }

--- a/src/org/graphstream/ui/view/View.java
+++ b/src/org/graphstream/ui/view/View.java
@@ -33,6 +33,7 @@ package org.graphstream.ui.view;
 
 import org.graphstream.ui.graphicGraph.GraphicElement;
 import org.graphstream.ui.graphicGraph.GraphicGraph;
+import org.graphstream.ui.view.util.InteractiveElement;
 import org.graphstream.ui.view.util.MouseManager;
 import org.graphstream.ui.view.util.ShortcutManager;
 
@@ -40,6 +41,7 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.util.Collection;
+import java.util.EnumSet;
 
 /**
  * A view on a graphic graph.
@@ -60,22 +62,26 @@ public interface View {
 	Camera getCamera();
 
 	/**
-	 * Search for the first node or sprite (in that order) that contains the
+	 * Search for the first GraphicElement among the specified types (precedence: node, edge, sprite) that contains the
 	 * point at coordinates (x, y).
 	 *
+     * @param types
+	 * 			  The types to check
 	 * @param x
 	 *            The point abscissa.
 	 * @param y
 	 *            The point ordinate.
-	 * @return The first node or sprite at the given coordinates or null if
+	 * @return The first GraphicElement among the specified types at the given coordinates or null if
 	 *         nothing found.
 	 */
-	GraphicElement findNodeOrSpriteAt(double x, double y);
+	GraphicElement findGraphicElementAt(EnumSet<InteractiveElement> types, double x, double y);
 
 	/**
-	 * Search for all the nodes and sprites contained inside the rectangle
+	 * Search for all the graphic elements contained inside the rectangle
 	 * (x1,y1)-(x2,y2).
 	 *
+	 * @param types
+	 * 			  The set of types to check
 	 * @param x1
 	 *            The rectangle lowest point abscissa.
 	 * @param y1
@@ -84,9 +90,9 @@ public interface View {
 	 *            The rectangle highest point abscissa.
 	 * @param y2
 	 *            The rectangle highest point ordinate.
-	 * @return The set of sprites and nodes in the given rectangle.
+	 * @return The set of sprites, nodes, and edges in the given rectangle.
 	 */
-	Collection<GraphicElement> allNodesOrSpritesIn(double x1, double y1, double x2, double y2);
+	Collection<GraphicElement> allGraphicElementsIn(EnumSet<InteractiveElement> types, double x1, double y1, double x2, double y2);
 
 	/**
 	 * Redisplay or update the view contents. Called by the Viewer.
@@ -247,4 +253,6 @@ public interface View {
 	 *            the listener
 	 */
 	void removeMouseMotionListener(MouseMotionListener l);
+
+
 }

--- a/src/org/graphstream/ui/view/util/InteractiveElement.java
+++ b/src/org/graphstream/ui/view/util/InteractiveElement.java
@@ -1,16 +1,18 @@
+package org.graphstream.ui.view.util;
+
 /*
- * Copyright 2006 - 2016
+ * Copyright 2006 - 2017
  *     Stefan Balev     <stefan.balev@graphstream-project.org>
  *     Julien Baudry    <julien.baudry@graphstream-project.org>
  *     Antoine Dutot    <antoine.dutot@graphstream-project.org>
  *     Yoann Pigné      <yoann.pigne@graphstream-project.org>
  *     Guilhelm Savin   <guilhelm.savin@graphstream-project.org>
- * 
+ *
  * This file is part of GraphStream <http://graphstream-project.org>.
- * 
+ *
  * GraphStream is a library whose purpose is to handle static or dynamic
  * graph, create them from scratch, file or any source and display them.
- * 
+ *
  * This program is free software distributed under the terms of two licenses, the
  * CeCILL-C license that fits European law, and the GNU Lesser General Public
  * License. You can  use, modify and/ or redistribute the software under the terms
@@ -18,47 +20,17 @@
  * URL <http://www.cecill.info> or under the terms of the GNU LGPL as published by
  * the Free Software Foundation, either version 3 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
-package org.graphstream.ui.view.util;
-
-import org.graphstream.ui.graphicGraph.GraphicGraph;
-import org.graphstream.ui.view.View;
-
-import javax.swing.event.MouseInputListener;
-import java.util.EnumSet;
-
-/**
- * A global behavior for all mouse events on graphic elements.
- */
-public interface MouseManager extends MouseInputListener {
-	/**
-	 * Make the manager active on the given graph and view.
-	 * @param graph
-	 *            The graph to control.
-	 * @param view
-	 *            The view to control.
-	 */
-	void init(GraphicGraph graph, View view);
-
-	/**
-	 * Release the links between this manager and the view and the graph.
-	 */
-	void release();
-
-	/**
-	 * Returns the set of InteractiveElements managed by the MouseManager
-	 *
-	 * @return the set of InteractiveElements managed by the MouseManager
-	 */
-	public EnumSet<InteractiveElement> getManagedTypes();
+public enum InteractiveElement {
+    NODE, EDGE, SPRITE
 }

--- a/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
+++ b/src/org/graphstream/ui/view/util/MouseOverMouseManager.java
@@ -58,6 +58,7 @@ public class MouseOverMouseManager extends DefaultMouseManager {
      *              the attribute is assigned without delay.
      */
     public MouseOverMouseManager(final long delay) {
+        super();
         this.delay = delay;
     }
 
@@ -78,7 +79,7 @@ public class MouseOverMouseManager extends DefaultMouseManager {
         try {
             hoverLock.lockInterruptibly();
             boolean stayedOnElement = false;
-            GraphicElement currentElement = view.findNodeOrSpriteAt(event.getX(), event.getY());
+            GraphicElement currentElement = view.findGraphicElementAt(getManagedTypes(),event.getX(), event.getY());
             if (hoveredElement != null) {
                 stayedOnElement = currentElement == null ? false : currentElement.equals(hoveredElement);
                 if (!stayedOnElement && hoveredElement.hasAttribute("ui.mouseOver")) {


### PR DESCRIPTION
I was revisiting using your library and wanted to have the ability to select edges.

I generalized methods to find graphic elements by type.  I kept DefaultMouseManager's default constructor to only send methods for nodes and sprites, but allow another constructor to define which methods will be listening.  This also has a side benefit of being able to specify which graphic objects will be checked, so someone could only allow certain types to be selected.

Right now, the edge is selected if the selected area encompasses the midpoint of the edge, since this is the GraphicEdge's X and Y coordinates.  I was unsure if it would be better for the selection to require the full edge to be within the selection.  If this were the case, then the nodes would have to be selected as well.

Although I did also add code for finding an edge in the click event, it's debated if this is worthwhile since it seems difficult to click the exact midpoint of the edge w/o any visual representation.  Perhaps it would be better to test if any point of the edge was clicked.