### PR TITLE
Change iterator() in Graph and Node to return an iterator that allows remove()

### DIFF
--- a/src/org/graphstream/graph/Graph.java
+++ b/src/org/graphstream/graph/Graph.java
@@ -32,6 +32,7 @@
 package org.graphstream.graph;
 
 import java.io.IOException;
+import java.util.Iterator;
 
 import org.graphstream.stream.AttributeSink;
 import org.graphstream.stream.ElementSink;
@@ -935,4 +936,14 @@ public interface Graph extends Element, Pipe, Iterable<Node>, Structure {
 	 * @return The removed node
 	 */
 	Node removeNode(Node node);
+
+	/**
+	 * This iterator fulfills the optional <code>remove()</code> method from Iterator.
+	 * Use this instead of <code>edges()</code> when removing edges during iteration is required.
+	 *
+	 * @return an iterator of the edges
+	 */
+	@Override
+	public Iterator<Node> iterator();
+
 }

--- a/src/org/graphstream/graph/Node.java
+++ b/src/org/graphstream/graph/Node.java
@@ -31,7 +31,6 @@
  */
 package org.graphstream.graph;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
@@ -385,10 +384,14 @@ public interface Node extends Element, Iterable<Edge> {
 		return edges().filter(e -> ( e.getTargetNode() == this ));
 	}
 
+	/**
+	 * This iterator fulfills the optional <code>remove()</code> method from Iterator.
+	 * Use this instead of <code>nodes()</code> when removing nodes during iteration is required.
+	 *
+	 * @return an iterator of the nodes
+	 */
 	@Override
-	default Iterator<Edge> iterator() {
-		return edges().iterator();
-	}
+	public Iterator<Edge> iterator();
 
 	/**
 	 * Override the Object.toString() method.

--- a/src/org/graphstream/graph/implementations/AbstractGraph.java
+++ b/src/org/graphstream/graph/implementations/AbstractGraph.java
@@ -51,7 +51,6 @@ import org.graphstream.ui.view.Viewer;
 import org.graphstream.util.GraphListeners;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.stream.Collectors;
 
 /**
@@ -128,18 +127,6 @@ public abstract class AbstractGraph extends AbstractElement implements Graph,
 									String attribute, Object oldValue, Object newValue) {
 		listeners.sendAttributeChangedEvent(id, SourceBase.ElementType.GRAPH,
 				attribute, event, oldValue, newValue);
-	}
-
-	// *** Inherited from graph ***
-
-	/**
-	 * This implementation returns an iterator over nodes.
-	 *
-	 * @see java.lang.Iterable#iterator()
-	 */
-	@Override
-	public Iterator<Node> iterator() {
-		return nodes().iterator();
 	}
 
 	// Factories

--- a/src/org/graphstream/graph/implementations/AdjacencyListGraph.java
+++ b/src/org/graphstream/graph/implementations/AdjacencyListGraph.java
@@ -220,6 +220,11 @@ public class AdjacencyListGraph extends AbstractGraph {
 	}
 
 	@Override
+	public Iterator<Node> iterator() {
+		return new NodeIterator<>();
+	}
+
+	@Override
 	public Edge getEdge(String id) {
 		return edgeMap.get(id);
 	}
@@ -261,11 +266,13 @@ public class AdjacencyListGraph extends AbstractGraph {
 		int iNext = 0;
 		int iPrev = -1;
 
+		@Override
 		public boolean hasNext() {
 			return iNext < edgeCount;
 		}
 
 		@SuppressWarnings("unchecked")
+		@Override
 		public T next() {
 			if (iNext >= edgeCount)
 				throw new NoSuchElementException();
@@ -273,12 +280,13 @@ public class AdjacencyListGraph extends AbstractGraph {
 			return (T) edgeArray[iPrev];
 		}
 
+		@Override
 		public void remove() {
 			if (iPrev == -1)
 				throw new IllegalStateException();
 			removeEdge(edgeArray[iPrev], true, true, true);
 			iNext = iPrev;
-			iPrev = -1;
+			iPrev -= 1;
 		}
 	}
 
@@ -286,11 +294,13 @@ public class AdjacencyListGraph extends AbstractGraph {
 		int iNext = 0;
 		int iPrev = -1;
 
+		@Override
 		public boolean hasNext() {
 			return iNext < nodeCount;
 		}
 
 		@SuppressWarnings("unchecked")
+		@Override
 		public T next() {
 			if (iNext >= nodeCount)
 				throw new NoSuchElementException();
@@ -298,12 +308,13 @@ public class AdjacencyListGraph extends AbstractGraph {
 			return (T) nodeArray[iPrev];
 		}
 
+		@Override
 		public void remove() {
 			if (iPrev == -1)
 				throw new IllegalStateException();
 			removeNode(nodeArray[iPrev], true);
 			iNext = iPrev;
-			iPrev = -1;
+			iPrev -= 1;
 		}
 	}
 

--- a/src/org/graphstream/graph/implementations/AdjacencyListNode.java
+++ b/src/org/graphstream/graph/implementations/AdjacencyListNode.java
@@ -243,6 +243,11 @@ public class AdjacencyListNode extends AbstractNode {
 		return Arrays.stream(edges, ioStart, degree);
 	}
 
+	@Override
+	public Iterator<Edge> iterator() {
+		return new EdgeIterator<>(IO_EDGE);
+	}
+
 	protected class EdgeIterator<T extends Edge> implements Iterator<T> {
 		protected int iPrev, iNext, iEnd;
 
@@ -256,11 +261,13 @@ public class AdjacencyListNode extends AbstractNode {
 				iNext = ioStart;
 		}
 
+		@Override
 		public boolean hasNext() {
 			return iNext < iEnd;
 		}
 
 		@SuppressWarnings("unchecked")
+		@Override
 		public T next() {
 			if (iNext >= iEnd)
 				throw new NoSuchElementException();
@@ -268,6 +275,7 @@ public class AdjacencyListNode extends AbstractNode {
 			return (T) edges[iPrev];
 		}
 
+	@Override
 		public void remove() {
 			if (iPrev == -1)
 				throw new IllegalStateException();
@@ -277,7 +285,7 @@ public class AdjacencyListNode extends AbstractNode {
 					e.target != AdjacencyListNode.this);
 			removeEdge(iPrev);
 			iNext = iPrev;
-			iPrev = -1;
+			iPrev -= 1;
 			iEnd--;
 		}
 	}


### PR DESCRIPTION
The changes to the api in terms of streams is great. The biggest downside, however, is their lack of modifying ability. Most noticeably, it's not possible to remove nodes during iteration. As the Node and Edge iterators are already in AdjacencyListNode/Graph, this is a simple solution. It might be worth it to reconsider using Streams, and instead use Collections. However, I haven't thought of a clean way to do this, but maybe somebody else will.