### PR TITLE
Throw NullAttributeException if attributes == null

### DIFF
--- a/src/org/graphstream/graph/implementations/AbstractElement.java
+++ b/src/org/graphstream/graph/implementations/AbstractElement.java
@@ -225,14 +225,13 @@ public abstract class AbstractElement implements Element {
 	public <T> T getFirstAttributeOf(Class<T> clazz, String... keys) {
 		Object o = null;
 
-		if (attributes == null)
-			return null;
+		if (attributes != null) {
+			for (String key : keys) {
+				o = attributes.get(key);
 
-		for (String key : keys) {
-			o = attributes.get(key);
-
-			if (o != null && clazz.isInstance(o))
-				return (T) o;
+				if (o != null && clazz.isInstance(o))
+					return (T) o;
+			}
 		}
 
 		if (nullAttributesAreErrors())


### PR DESCRIPTION
`AbstractElement.getFirstAttributeOf(Class<T>, String...)` should throw `NullAttributeException` if `nullAttributesAreErrors()` returns true and the attributes map is null. It incorrectly returns null in this condition. This patch fixes this bug.

Here's an example:
```java
SingleGraph graph = new SingleGraph("graph");
graph.setNullAttributesAreErrors(true);
graph.getFirstAttributeOf(String.class, "foo"); // Should throw.
```

If returning null is an expected behavior, `AbstractElement.getFirstAttributeOf(String...)` may need to be fixed instead for consistency.