### PR TITLE
Allow CSS styles to be inherited when events occur

### DIFF
--- a/src-test/org/graphstream/ui/graphicGraph/parser/test/TestStyleSheet.java
+++ b/src-test/org/graphstream/ui/graphicGraph/parser/test/TestStyleSheet.java
@@ -5,12 +5,12 @@
  *     Antoine Dutot    <antoine.dutot@graphstream-project.org>
  *     Yoann Pigné      <yoann.pigne@graphstream-project.org>
  *     Guilhelm Savin   <guilhelm.savin@graphstream-project.org>
- * 
+ *
  * This file is part of GraphStream <http://graphstream-project.org>.
- * 
+ *
  * GraphStream is a library whose purpose is to handle static or dynamic
  * graph, create them from scratch, file or any source and display them.
- * 
+ *
  * This program is free software distributed under the terms of two licenses, the
  * CeCILL-C license that fits European law, and the GNU Lesser General Public
  * License. You can  use, modify and/ or redistribute the software under the terms
@@ -18,14 +18,14 @@
  * URL <http://www.cecill.info> or under the terms of the GNU LGPL as published by
  * the Free Software Foundation, either version 3 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
@@ -52,7 +52,7 @@ import static org.junit.Assert.*;
 
 /**
  * Run several tests on the style sheet package.
- * 
+ *
  * @author Antoine Dutot
  */
 public class TestStyleSheet {
@@ -315,6 +315,20 @@ public class TestStyleSheet {
 		assertEquals(3, sC.getStrokeWidth().value, 0);
 		assertEquals(3, sD.getStrokeWidth().value, 0);
 
+		// Ensure that inherited styles are still correct
+		assertTrue(sA.getFillColor(0).getRed() == 255
+				   && sA.getFillColor(0).getGreen() == 0
+				   && sA.getFillColor(0).getBlue() == 255);
+		assertTrue(sB.getFillColor(0).getRed() == 255
+				   && sB.getFillColor(0).getGreen() == 165
+				   && sB.getFillColor(0).getBlue() == 0);
+		assertTrue(sC.getFillColor(0).getRed() == 255
+				   && sC.getFillColor(0).getGreen() == 165
+				   && sC.getFillColor(0).getBlue() == 0);
+		assertTrue(sD.getFillColor(0).getRed() == 190
+				   && sD.getFillColor(0).getGreen() == 190
+				   && sD.getFillColor(0).getBlue() == 190);
+
 		sgs.popEvent("clicked"); // This is normally done automatically by the
 									// GraphicElement
 
@@ -340,6 +354,20 @@ public class TestStyleSheet {
 		assertEquals(3, sB.getStrokeWidth().value, 0);
 		assertEquals(3, sC.getStrokeWidth().value, 0);
 		assertEquals(3, sD.getStrokeWidth().value, 0);
+
+		// Ensure that inherited styles are still correct
+		assertTrue(sA.getFillColor(0).getRed() == 255
+				   && sA.getFillColor(0).getGreen() == 0
+				   && sA.getFillColor(0).getBlue() == 255);
+		assertTrue(sB.getFillColor(0).getRed() == 255
+				   && sB.getFillColor(0).getGreen() == 165
+				   && sB.getFillColor(0).getBlue() == 0);
+		assertTrue(sC.getFillColor(0).getRed() == 255
+				   && sC.getFillColor(0).getGreen() == 165
+				   && sC.getFillColor(0).getBlue() == 0);
+		assertTrue(sD.getFillColor(0).getRed() == 190
+				   && sD.getFillColor(0).getGreen() == 190
+				   && sD.getFillColor(0).getBlue() == 190);
 
 		sgs.popEvent("clicked"); // This is normally done automatically by the
 									// GraphicElement

--- a/src/org/graphstream/ui/graphicGraph/stylesheet/Style.java
+++ b/src/org/graphstream/ui/graphicGraph/stylesheet/Style.java
@@ -5,12 +5,12 @@
  *     Antoine Dutot    <antoine.dutot@graphstream-project.org>
  *     Yoann Pigné      <yoann.pigne@graphstream-project.org>
  *     Guilhelm Savin   <guilhelm.savin@graphstream-project.org>
- * 
+ *
  * This file is part of GraphStream <http://graphstream-project.org>.
- * 
+ *
  * GraphStream is a library whose purpose is to handle static or dynamic
  * graph, create them from scratch, file or any source and display them.
- * 
+ *
  * This program is free software distributed under the terms of two licenses, the
  * CeCILL-C license that fits European law, and the GNU Lesser General Public
  * License. You can  use, modify and/ or redistribute the software under the terms
@@ -18,14 +18,14 @@
  * URL <http://www.cecill.info> or under the terms of the GNU LGPL as published by
  * the Free Software Foundation, either version 3 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C and LGPL licenses and that you accept their terms.
  */
@@ -38,7 +38,7 @@ import java.util.Iterator;
 
 /**
  * A style is a whole set of settings for a graphic element.
- * 
+ *
  * <p>
  * Styles inherit each others. By default a style is all set to invalid values
  * meaning "unset". This means that the value is to be taken from the parent.
@@ -78,7 +78,7 @@ public class Style extends StyleConstants {
 	/**
 	 * New style with all settings to a special value meaning "unset". In this
 	 * modeField, all the settings are inherited from the parent.
-	 * 
+	 *
 	 * @param parent
 	 *            The parent style.
 	 */
@@ -91,7 +91,7 @@ public class Style extends StyleConstants {
 
 	/**
 	 * The parent style.
-	 * 
+	 *
 	 * @return a style from which some settings are inherited.
 	 */
 	public Rule getParent() {
@@ -100,23 +100,23 @@ public class Style extends StyleConstants {
 
 	/**
 	 * Get the value of a given property.
-	 * 
+	 *
 	 * This code is the same for all "getX" methods so we explain it once here.
 	 * This is the implementation of style inheritance.
-	 * 
+	 *
 	 * First if some event is actually occurring, the alternative styles are
 	 * searched first. If these events have unset values for the property, their
 	 * parent are then searched.
-	 * 
+	 *
 	 * If the value for the property is not found in the alternative styles,
 	 * alternative styles parents, or if there is no event occurring actually,
 	 * this style is checked.
-	 * 
+	 *
 	 * If its value is unset, the parents of this style are checked.
-	 * 
+	 *
 	 * Classes are not checked here, they are processed in the
 	 * {@link org.graphstream.ui.graphicGraph.StyleGroup} class.
-	 * 
+	 *
 	 * @param property
 	 *            The style property the value is searched for.
 	 */
@@ -164,23 +164,32 @@ public class Style extends StyleConstants {
 
 	/**
 	 * True if the given field exists in this style only (not the parents).
-	 * 
+	 *
 	 * @param field
 	 *            The field to test.
 	 * @return True if this style has a value for the given field.
 	 */
 	public boolean hasValue(String field, String... events) {
+		boolean hasValue = false;
+
 		if (events != null && events.length > 0 && alternates != null) {
 			for (String event : events) {
 				Rule rule = alternates.get(event);
 
 				if (rule != null) {
-					return rule.getStyle().hasValue(field);
+					if (rule.getStyle().hasValue(field)) {
+						hasValue = true;
+						break;
+					}
 				}
 			}
 		}
 
-		return (values.get(field) != null);
+		if (!hasValue) {
+			hasValue = (values.get(field) != null);
+		}
+
+		return hasValue;
 	}
 
 	// Individual style properties.
@@ -456,7 +465,7 @@ public class Style extends StyleConstants {
 
 		return null;
 	}
-	
+
 	/**
 	 * Offset of the text from its computed position.
 	 */
@@ -619,7 +628,7 @@ public class Style extends StyleConstants {
 	 * Copy all the settings of the other style that are set, excepted the
 	 * parent. Only the settings that have a value (different from "unset") are
 	 * copied. The parent field is never copied.
-	 * 
+	 *
 	 * @param other
 	 *            Another style.
 	 */
@@ -694,7 +703,7 @@ public class Style extends StyleConstants {
 
 	/**
 	 * Set or change the parent of the style.
-	 * 
+	 *
 	 * @param parent
 	 *            The new parent.
 	 */
@@ -704,7 +713,7 @@ public class Style extends StyleConstants {
 
 	/**
 	 * Add an alternative style for specific events.
-	 * 
+	 *
 	 * @param event
 	 *            The event that triggers the alternate style.
 	 * @param alternateStyle
@@ -793,7 +802,7 @@ public class Style extends StyleConstants {
 		/*
 		 * if( level >= 0 ) { if( parent != null ) { String rec =
 		 * parent.style.toString( level + 1 );
-		 * 
+		 *
 		 * builder.append( rec ); } }
 		 */
 		String res = builder.toString();


### PR DESCRIPTION
This pull request fixes an issue where inherited CSS styles are not found when an event occurs and alternate styles are being used.

For example:
```
node { fill-color: white; }
node.foo { fill-color: black; }
node.foo:clicked { size: 10px; }
```
In this example, when a node with class `foo` is clicked, its fill color will change from black back to white, because the styles in `node.foo` (in this case only `fill-color`) are not correctly inherited when the event is active.

The issue is simply that `Style.hasValue()` only checks the alternate (event-based) styles, and never gets to check the base style's values.

I've also added in some test code to detect this issue, although it's not overly comprehensive.