### PR TITLE
Changed `Style.toString()` to fully print the alternate styles

### DIFF
--- a/src/org/graphstream/ui/graphicGraph/stylesheet/Style.java
+++ b/src/org/graphstream/ui/graphicGraph/stylesheet/Style.java
@@ -753,14 +753,6 @@ public class Style extends StyleConstants {
 
 		}
 
-		if (alternates != null && alternates.size() > 0) {
-			builder.append(String.format(" /"));
-			for (Rule rule : alternates.values()) {
-				builder.append(' ');
-				builder.append(rule.selector.toString());
-			}
-		}
-
 		builder.append(String.format("%n"));
 
 		Iterator<String> i = values.keySet().iterator();
@@ -787,6 +779,13 @@ public class Style extends StyleConstants {
 			} else {
 				builder.append(String.format("%s%s%s%s: %s%n", prefix, sprefix,
 						sprefix, key, o != null ? o.toString() : "<null>"));
+			}
+		}
+
+		if (alternates != null && alternates.size() > 0) {
+			for (Rule rule : alternates.values()) {
+				// We use "level-1" to ensure that these styles line up with those above
+				builder.append(rule.toString(level - 1));
 			}
 		}
 


### PR DESCRIPTION
…rather than just the selectors, allowing the full stylesheet to be printed.