### PR TITLE
Normalize the mouse interaction

### DIFF
--- a/src/org/graphstream/ui/view/View.java
+++ b/src/org/graphstream/ui/view/View.java
@@ -201,7 +201,13 @@ public interface View {
 	 * @see org.graphstream.ui.view.util.ShortcutManager
 	 */
 	void setShortcutManager(ShortcutManager manager);
-
+	
+	/**
+	 * This is a shortcut to a call setShortcutManager with a MouseOverMouseManager instance and with
+	 * (InteractiveElement.EDGE, InteractiveElement.NODE, InteractiveElement.SPRITE).
+	 */
+	void enableMouseOptions();
+	
 	/**
 	 * Request ui focus.
 	 * 


### PR DESCRIPTION
Normalize the mouse interaction. Add a shortcut function in DefaultView for enable the edge selection and the over/left function.

```java
//old
viewer.getDefaultView().setMouseManager(new MouseOverMouseManager(EnumSet.of(InteractiveElement.EDGE, InteractiveElement.NODE, InteractiveElement.SPRITE)));

//new
viewer.getDefaultView().enableMouseOptions();
```
Allow the use of MouseOverMouseManager in javafx, to enable mouseOver and mouseLeft of ViewerListener. Only a shortcut to edge selection for android.

related Pull Request : 
- gs-ui-swing : https://github.com/graphstream/gs-ui-swing/pull/4
- gs-ui-javafx : https://github.com/graphstream/gs-ui-javafx/pull/15
- g-ui-android : https://github.com/graphstream/gs-ui-android/pull/5