### PR TITLE
AdjacencyListGraph does not check existence of a node/edge before shrinking array

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ then, add the `gs-core` to your dependencies:
 <dependency>
     <groupId>com.github.graphstream</groupId>
     <artifactId>gs-core</artifactId>
-    <version>2.0-alpha</version>
+    <version>2.0.0-beta</version>
 </dependency>
 ```
 
-You can use any version of `gs-core` you need. Simply specify the desired version in the `<version>` tag. The version can be a git tag name (e.g. `2.0-alpha`), a commit number, or a branch name followed by `-SNAPSHOT` (e.g. `dev-SNAPSHOT`). More details on the [possible versions on jitpack](https://jitpack.io/#graphstream/gs-core).
+You can use any version of `gs-core` you need. Simply specify the desired version in the `<version>` tag. The version can be a git tag name (e.g. `2.0.0-beta`), a commit number, or a branch name followed by `-SNAPSHOT` (e.g. `dev-SNAPSHOT`). More details on the [possible versions on jitpack](https://jitpack.io/#graphstream/gs-core).
 
 ## User interface
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 	<groupId>org.graphstream</groupId>
 	<artifactId>gs-core</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0-beta</version>
 
 	<name>gs-core</name>
 	<description>

--- a/src/org/graphstream/graph/implementations/AdjacencyListGraph.java
+++ b/src/org/graphstream/graph/implementations/AdjacencyListGraph.java
@@ -182,20 +182,22 @@ public class AdjacencyListGraph extends AbstractGraph {
 
 	@Override
 	protected void removeEdgeCallback(AbstractEdge edge) {
-		edgeMap.remove(edge.getId());
-		int i = edge.getIndex();
-		edgeArray[i] = edgeArray[--edgeCount];
-		edgeArray[i].setIndex(i);
-		edgeArray[edgeCount] = null;
+		if (edgeMap.remove(edge.getId()) != null) {
+			int i = edge.getIndex();
+			edgeArray[i] = edgeArray[--edgeCount];
+			edgeArray[i].setIndex(i);
+			edgeArray[edgeCount] = null;
+		}
 	}
 
 	@Override
 	protected void removeNodeCallback(AbstractNode node) {
-		nodeMap.remove(node.getId());
-		int i = node.getIndex();
-		nodeArray[i] = nodeArray[--nodeCount];
-		nodeArray[i].setIndex(i);
-		nodeArray[nodeCount] = null;
+		if (nodeMap.remove(node.getId()) != null) {
+			int i = node.getIndex();
+			nodeArray[i] = nodeArray[--nodeCount];
+	    		nodeArray[i].setIndex(i);
+			nodeArray[nodeCount] = null;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
When calling `AdjacencyListGraph.removeNode(n)` with a node `n` not present in the graph, it proceeds to call `removeNodeCallback(n)`. Despite `nodeMap.remove(...)` being a no-op in this case, the `nodeArray` loses the element in `nodeArray[node.getIndex()]`, which may actually also cause an `ArrayOutOfBoundsException`. The proposed change fixes this by checking if `nodeMap.remove(...)` actually found the node or not.

The same was done for edges.