### PR TITLE
Fixes a Path.add logic to prevent edges that are not connected to be added.

### DIFF
--- a/src-test/org/graphstream/graph/PathTest.java
+++ b/src-test/org/graphstream/graph/PathTest.java
@@ -1,0 +1,50 @@
+package org.graphstream.graph;
+
+import org.graphstream.graph.implementations.DefaultGraph;
+import org.junit.Test;
+
+public class PathTest {
+
+	@Test(expected = IllegalStateException.class)
+	public void setRoot_rootNodeMustBeNull() {
+		Graph graph = createSimpleGraph();
+		Path path = new Path();
+
+		path.setRoot(graph.getNode("a"));
+
+		// this has to fail, as root is already set
+		path.setRoot(graph.getNode("b"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void add_nodeHeadMustBeInEdge() {
+		Graph graph = createSimpleGraph();
+		Path path = new Path();
+
+		path.setRoot(graph.getNode("a"));
+
+		// this has to fail as there is no edge between nodes "a" and "c"
+		path.add(graph.getEdge("cd"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void add_whenAddingEdgeRootMustBeSet() {
+		Graph graph = createSimpleGraph();
+		Path path = new Path();
+
+		// this has to fail as root of the path is not set
+		path.add(graph.getEdge("ab"));
+	}
+
+	private Graph createSimpleGraph() {
+		Graph graph = new DefaultGraph("test");
+		graph.setStrict(false);
+		graph.setAutoCreate(true);
+
+		graph.addEdge("ab", "a", "b");
+		graph.addEdge("bc", "b", "c");
+		graph.addEdge("cd", "c", "d");
+
+		return graph;
+	}
+}

--- a/src/org/graphstream/graph/Path.java
+++ b/src/org/graphstream/graph/Path.java
@@ -102,8 +102,6 @@ public class Path implements Structure {
 		nodePath = new Stack<Node>();
 	}
 
-	// -------------- ACCESSORS --------------
-
 	/**
 	 * Get the root (the first node) of the path.
 	 * 
@@ -200,17 +198,16 @@ public class Path implements Structure {
 		return nodePath;
 	}
 
-	// -------------- MODIFIERS -------------
 
 	/**
-	 * Method that adds a node (and an edge) to the path. Parameters are the start
-	 * node : the one who already belong to the path or the first one if the path is
-	 * empty. The other parameter is the the new edge to add.
-	 * 
+	 * Adds a node and an edge to the path. If root is not set, the node will be
+	 * set as root. Otherwise from node must be the same as the head node of the
+	 * path.
+	 *
 	 * @param from
-	 *            The start node.
+	 * 		The start node.
 	 * @param edge
-	 *            The edge used.
+	 * 		The edge used.
 	 */
 	public void add(Node from, Edge edge) {
 		if (root == null) {
@@ -225,21 +222,23 @@ public class Path implements Structure {
 			from = nodePath.peek();
 		}
 
-		if (nodePath.size() == 1 || ((nodePath.peek() == from)
-				&& (from == edgePath.peek().getSourceNode() || from == edgePath.peek().getTargetNode()))) {
-
-			nodePath.push(edge.getOpposite(from));
-			edgePath.push(edge);
-		} else {
-			logger.warning("Cannot add the specified edge, it cannot be part of the path! %n");
+		if (!nodePath.peek().equals(from)) {
+			throw new IllegalArgumentException("From node must be at the head of the path");
 		}
+
+		if (!edge.getSourceNode().equals(from) && !edge.getTargetNode().equals(from)) {
+			throw new IllegalArgumentException("From node must be part of the edge");
+		}
+
+		nodePath.push(edge.getOpposite(from));
+		edgePath.push(edge);
 	}
 
 	/**
-	 * Method that adds an edge an a node to the path. The new edge to add is given.
-	 * 
+	 * Adds an edge to the path.
+	 *
 	 * @param edge
-	 *            The edge to add to the path.
+	 * 		The edge to add to the path.
 	 */
 	public void add(Edge edge) {
 		if (nodePath.isEmpty()) {


### PR DESCRIPTION
Previous logic allowed users to add any edge to the path when path length was one. This addresses that issue. 
In addition, I updated invalid state logic to be more strict. Previously, an error would be logged to the logger, but the code was allowed to continue running. This can cause unintended side affects in the user's code when using this library.